### PR TITLE
ch: u-boot: atf: Fix typo in file u-boot

### DIFF
--- a/u-boot/u-boot.sh
+++ b/u-boot/u-boot.sh
@@ -227,8 +227,8 @@ build_atf () {
 		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
 		${BUILD_DIR}/atf-tool/wtmi/*.d			\
 		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
-	make -j8 BL33=${BUILD_DIR}/u-boot-512m-spi.bin		\
-		CLOCKSPRESET=CPU_1200_DDR_750			\
+	export BL33=${BUILD_DIR}/u-boot-512m-spi.bin
+	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
 		DDR_TOPLOGY=0					\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
@@ -249,8 +249,8 @@ build_atf () {
 		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
 		${BUILD_DIR}/atf-tool/wtmi/*.d			\
 		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
-	make -j8 BL33=${BUILD_DIR}/u-boot-512m-mmc.bin		\
-		CLOCKSPRESET=CPU_1200_DDR_750			\
+	export BL33=${BUILD_DIR}/u-boot-512m-mmc.bin
+	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
 		DDR_TOPLOGY=0					\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
@@ -274,8 +274,8 @@ build_atf () {
 		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
 		${BUILD_DIR}/atf-tool/wtmi/*.d			\
 		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
-	make -j8 BL33=${BUILD_DIR}/u-boot-1g-spi.bin		\
-		CLOCKSPRESET=CPU_1200_DDR_750			\
+	export BL33=${BUILD_DIR}/u-boot-1g-spi.bin
+	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
 		DDR_TOPLOGY=4					\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
@@ -296,8 +296,8 @@ build_atf () {
 		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
 		${BUILD_DIR}/atf-tool/wtmi/*.d			\
 		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
-	make -j8 BL33=${BUILD_DIR}/u-boot-1g-mmc.bin		\
-		CLOCKSPRESET=CPU_1200_DDR_750			\
+	export BL33=${BUILD_DIR}/u-boot-1g-mmc.bin
+	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
 		DDR_TOPLOGY=4					\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
@@ -320,8 +320,8 @@ build_atf () {
 		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
 		${BUILD_DIR}/atf-tool/wtmi/*.d			\
 		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
-	make -j8 BL33=${BUILD_DIR}/u-boot-1g-spi.bin		\
-		CLOCKSPRESET=CPU_1200_DDR_750			\
+	export BL33=${BUILD_DIR}/u-boot-1g-spi.bin
+	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
 		DDR_TOPLOGY=2					\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
@@ -342,8 +342,8 @@ build_atf () {
 		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
 		${BUILD_DIR}/atf-tool/wtmi/*.d			\
 		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
-	make -j8 BL33=${BUILD_DIR}/u-boot-1g-mmc.bin		\
-		CLOCKSPRESET=CPU_1200_DDR_750			\
+	export BL33=${BUILD_DIR}/u-boot-1g-mmc.bin
+	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
 		DDR_TOPLOGY=2					\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
@@ -366,8 +366,8 @@ build_atf () {
 		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
 		${BUILD_DIR}/atf-tool/wtmi/*.d			\
 		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
-	make -j8 BL33=${BUILD_DIR}/u-boot-2g-spi.bin		\
-		CLOCKSPRESET=CPU_1200_DDR_750			\
+	export BL33=${BUILD_DIR}/u-boot-2g-spi.bin
+	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
 		DDR_TOPLOGY=7					\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
@@ -388,8 +388,8 @@ build_atf () {
 		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
 		${BUILD_DIR}/atf-tool/wtmi/*.d			\
 		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
-	make -j8 BL33=${BUILD_DIR}/u-boot-2g-mmc.bin		\
-		CLOCKSPRESET=CPU_1200_DDR_750			\
+	export BL33=${BUILD_DIR}/u-boot-2g-mmc.bin
+	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
 		DDR_TOPLOGY=7					\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\

--- a/u-boot/u-boot.sh
+++ b/u-boot/u-boot.sh
@@ -223,154 +223,186 @@ build_atf () {
 	### Build DDR3 512M 1CS
 	## Build DDR3 512M 1CS SPI
 	make distclean
-	make -j8 BL33=${BUILD_DIR}/u-boot-512m-spi.bin	\
-		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPLOGY=0				\
-		BOOTDEV=SPINOR				\
-		WTP=${BUILD_DIR}/atf-tool		\
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
+		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
+		${BUILD_DIR}/atf-tool/wtmi/*.d			\
+		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	make -j8 BL33=${BUILD_DIR}/u-boot-512m-spi.bin		\
+		CLOCKSPRESET=CPU_1200_DDR_750			\
+		DDR_TOPLOGY=0					\
+		BOOTDEV=SPINOR					\
+		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
 	if [ $? -ne 0 ]
 	then
 		echo "Build ddr3-512m-1cs-spi failed!"
 		exit 1
 	fi
-	cp build/a3700/release/flash-image.bin		\
+	cp build/a3700/release/flash-image.bin			\
 		${IMAGE_DIR}/u-boot/ddr3/512m/1cs/spi
-	cp -R build/a3700/release/uart-images		\
+	cp -R build/a3700/release/uart-images			\
 		${IMAGE_DIR}/u-boot/ddr3/512m/1cs/spi
 
 	## Build DDR3 512M 1CS MMC
 	make distclean
-	make -j8 BL33=${BUILD_DIR}/u-boot-512m-mmc.bin	\
-		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPLOGY=0				\
-		BOOTDEV=EMMCNORM			\
-		PARTNUM=1				\
-		WTP=${BUILD_DIR}/atf-tool		\
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
+		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
+		${BUILD_DIR}/atf-tool/wtmi/*.d			\
+		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	make -j8 BL33=${BUILD_DIR}/u-boot-512m-mmc.bin		\
+		CLOCKSPRESET=CPU_1200_DDR_750			\
+		DDR_TOPLOGY=0					\
+		BOOTDEV=EMMCNORM				\
+		PARTNUM=1					\
+		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
 	if [ $? -ne 0 ]
 	then
 		echo "Build ddr3-512m-1cs-mmc failed!"
 		exit 1
 	fi
-	cp build/a3700/release/flash-image.bin		\
+	cp build/a3700/release/flash-image.bin			\
 		${IMAGE_DIR}/u-boot/ddr3/512m/1cs/mmc
-	cp -R build/a3700/release/uart-images		\
+	cp -R build/a3700/release/uart-images			\
 		${IMAGE_DIR}/u-boot/ddr3/512m/1cs/mmc
 
 	#### Build DDR3 1G
 	### Build DDR3 1G 1CS
 	## Build DDR3 1G 1CS SPI
 	make distclean
-	make -j8 BL33=${BUILD_DIR}/u-boot-1g-spi.bin	\
-		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPLOGY=4				\
-		BOOTDEV=SPINOR				\
-		WTP=${BUILD_DIR}/atf-tool		\
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
+		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
+		${BUILD_DIR}/atf-tool/wtmi/*.d			\
+		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	make -j8 BL33=${BUILD_DIR}/u-boot-1g-spi.bin		\
+		CLOCKSPRESET=CPU_1200_DDR_750			\
+		DDR_TOPLOGY=4					\
+		BOOTDEV=SPINOR					\
+		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
 	if [ $? -ne 0 ]
 	then
 		echo "Build ddr3-1g-1cs-spi failed!"
 		exit 1
 	fi
-	cp build/a3700/release/flash-image.bin		\
+	cp build/a3700/release/flash-image.bin			\
 		${IMAGE_DIR}/u-boot/ddr3/1g/1cs/spi
-	cp -R build/a3700/release/uart-images		\
+	cp -R build/a3700/release/uart-images			\
 		${IMAGE_DIR}/u-boot/ddr3/1g/1cs/spi
 
 	## Build DDR3 1G 1CS MMC
 	make distclean
-	make -j8 BL33=${BUILD_DIR}/u-boot-1g-mmc.bin	\
-		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPLOGY=4				\
-		BOOTDEV=EMMCNORM			\
-		PARTNUM=1				\
-		WTP=${BUILD_DIR}/atf-tool		\
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
+		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
+		${BUILD_DIR}/atf-tool/wtmi/*.d			\
+		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	make -j8 BL33=${BUILD_DIR}/u-boot-1g-mmc.bin		\
+		CLOCKSPRESET=CPU_1200_DDR_750			\
+		DDR_TOPLOGY=4					\
+		BOOTDEV=EMMCNORM				\
+		PARTNUM=1					\
+		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
 	if [ $? -ne 0 ]
 	then
 		echo "Build ddr3-1g-1cs-mmc failed!"
 		exit 1
 	fi
-	cp build/a3700/release/flash-image.bin		\
+	cp build/a3700/release/flash-image.bin			\
 		${IMAGE_DIR}/u-boot/ddr3/1g/1cs/mmc
-	cp -R build/a3700/release/uart-images		\
+	cp -R build/a3700/release/uart-images			\
 		${IMAGE_DIR}/u-boot/ddr3/1g/1cs/mmc
 
 	### Build DDR3 1G 2CS
 	## Build DDR3 1G 2CS SPI
 	make distclean
-	make -j8 BL33=${BUILD_DIR}/u-boot-1g-spi.bin	\
-		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPLOGY=2				\
-		BOOTDEV=SPINOR				\
-		WTP=${BUILD_DIR}/atf-tool		\
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
+		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
+		${BUILD_DIR}/atf-tool/wtmi/*.d			\
+		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	make -j8 BL33=${BUILD_DIR}/u-boot-1g-spi.bin		\
+		CLOCKSPRESET=CPU_1200_DDR_750			\
+		DDR_TOPLOGY=2					\
+		BOOTDEV=SPINOR					\
+		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
 	if [ $? -ne 0 ]
 	then
 		echo "Build ddr3-1g-2cs-spi failed!"
 		exit 1
 	fi
-	cp build/a3700/release/flash-image.bin		\
+	cp build/a3700/release/flash-image.bin			\
 		${IMAGE_DIR}/u-boot/ddr3/1g/2cs/spi
-	cp -R build/a3700/release/uart-images		\
+	cp -R build/a3700/release/uart-images			\
 		${IMAGE_DIR}/u-boot/ddr3/1g/2cs/spi
 
 	## Build DDR3 1G 2CS MMC
 	make distclean
-	make -j8 BL33=${BUILD_DIR}/u-boot-1g-mmc.bin	\
-		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPLOGY=2				\
-		BOOTDEV=EMMCNORM			\
-		PARTNUM=1				\
-		WTP=${BUILD_DIR}/atf-tool		\
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
+		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
+		${BUILD_DIR}/atf-tool/wtmi/*.d			\
+		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	make -j8 BL33=${BUILD_DIR}/u-boot-1g-mmc.bin		\
+		CLOCKSPRESET=CPU_1200_DDR_750			\
+		DDR_TOPLOGY=2					\
+		BOOTDEV=EMMCNORM				\
+		PARTNUM=1					\
+		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
 	if [ $? -ne 0 ]
 	then
 		echo "Build ddr3-1g-2cs-mmc failed!"
 		exit 1
 	fi
-	cp build/a3700/release/flash-image.bin		\
+	cp build/a3700/release/flash-image.bin			\
 		${IMAGE_DIR}/u-boot/ddr3/1g/2cs/mmc
-	cp -R build/a3700/release/uart-images		\
+	cp -R build/a3700/release/uart-images			\
 		${IMAGE_DIR}/u-boot/ddr3/1g/2cs/mmc
 
 	### Build DDR3 2G 2CS
 	## Build DDR3 2G 2CS SPI
 	make distclean
-	make -j8 BL33=${BUILD_DIR}/u-boot-2g-spi.bin	\
-		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPLOGY=7				\
-		BOOTDEV=SPINOR				\
-		WTP=${BUILD_DIR}/atf-tool		\
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
+		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
+		${BUILD_DIR}/atf-tool/wtmi/*.d			\
+		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	make -j8 BL33=${BUILD_DIR}/u-boot-2g-spi.bin		\
+		CLOCKSPRESET=CPU_1200_DDR_750			\
+		DDR_TOPLOGY=7					\
+		BOOTDEV=SPINOR					\
+		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
 	if [ $? -ne 0 ]
 	then
 		echo "Build ddr3-2g-2cs-spi failed!"
 		exit 1
 	fi
-	cp build/a3700/release/flash-image.bin		\
+	cp build/a3700/release/flash-image.bin			\
 		${IMAGE_DIR}/u-boot/ddr3/2g/2cs/spi
-	cp -R build/a3700/release/uart-images		\
+	cp -R build/a3700/release/uart-images			\
 		${IMAGE_DIR}/u-boot/ddr3/2g/2cs/spi
 
 	## Build DDR3 2G 2CS MMC
 	make distclean
-	make -j8 BL33=${BUILD_DIR}/u-boot-2g-mmc.bin	\
-		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPLOGY=7				\
-		BOOTDEV=EMMCNORM			\
-		PARTNUM=1				\
-		WTP=${BUILD_DIR}/atf-tool		\
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
+		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
+		${BUILD_DIR}/atf-tool/wtmi/*.d			\
+		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	make -j8 BL33=${BUILD_DIR}/u-boot-2g-mmc.bin		\
+		CLOCKSPRESET=CPU_1200_DDR_750			\
+		DDR_TOPLOGY=7					\
+		BOOTDEV=EMMCNORM				\
+		PARTNUM=1					\
+		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
 	if [ $? -ne 0 ]
 	then
 		echo "Build ddr3-2g-2cs-mmc failed!"
 		exit 1
 	fi
-	cp build/a3700/release/flash-image.bin		\
+	cp build/a3700/release/flash-image.bin			\
 		${IMAGE_DIR}/u-boot/ddr3/2g/2cs/mmc
-	cp -R build/a3700/release/uart-images		\
+	cp -R build/a3700/release/uart-images			\
 		${IMAGE_DIR}/u-boot/ddr3/2g/2cs/mmc
 
 	cd -

--- a/u-boot/u-boot.sh
+++ b/u-boot/u-boot.sh
@@ -195,6 +195,20 @@ build_u_boot () {
 	cd -
 }
 
+build_atf_tool_clean () {
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
+		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
+		${BUILD_DIR}/atf-tool/wtmi/*.d
+
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.o		\
+		${BUILD_DDR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.o
+
+	rm -rf ${BUILD_DIR}/atf-tool/wtmi/*.o
+
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	rm -rf ${BUILD_DIR}/atf-tool/ddr/tim_ddr/ddr_static.txt
+}
+
 build_atf () {
 	cd ${BUILD_DIR}/atf
 
@@ -223,13 +237,10 @@ build_atf () {
 	### Build DDR3 512M 1CS
 	## Build DDR3 512M 1CS SPI
 	make distclean
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
-		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
-		${BUILD_DIR}/atf-tool/wtmi/*.d			\
-		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-512m-spi.bin
 	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
-		DDR_TOPLOGY=0					\
+		DDR_TOPOLOGY=0					\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
@@ -245,13 +256,10 @@ build_atf () {
 
 	## Build DDR3 512M 1CS MMC
 	make distclean
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
-		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
-		${BUILD_DIR}/atf-tool/wtmi/*.d			\
-		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-512m-mmc.bin
 	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
-		DDR_TOPLOGY=0					\
+		DDR_TOPOLOGY=0					\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
 		WTP=${BUILD_DIR}/atf-tool			\
@@ -270,13 +278,10 @@ build_atf () {
 	### Build DDR3 1G 1CS
 	## Build DDR3 1G 1CS SPI
 	make distclean
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
-		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
-		${BUILD_DIR}/atf-tool/wtmi/*.d			\
-		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-1g-spi.bin
 	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
-		DDR_TOPLOGY=4					\
+		DDR_TOPOLOGY=4					\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
@@ -292,13 +297,10 @@ build_atf () {
 
 	## Build DDR3 1G 1CS MMC
 	make distclean
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
-		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
-		${BUILD_DIR}/atf-tool/wtmi/*.d			\
-		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-1g-mmc.bin
 	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
-		DDR_TOPLOGY=4					\
+		DDR_TOPOLOGY=4					\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
 		WTP=${BUILD_DIR}/atf-tool			\
@@ -316,13 +318,10 @@ build_atf () {
 	### Build DDR3 1G 2CS
 	## Build DDR3 1G 2CS SPI
 	make distclean
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
-		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
-		${BUILD_DIR}/atf-tool/wtmi/*.d			\
-		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-1g-spi.bin
 	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
-		DDR_TOPLOGY=2					\
+		DDR_TOPOLOGY=2					\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
@@ -338,13 +337,10 @@ build_atf () {
 
 	## Build DDR3 1G 2CS MMC
 	make distclean
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
-		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
-		${BUILD_DIR}/atf-tool/wtmi/*.d			\
-		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-1g-mmc.bin
 	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
-		DDR_TOPLOGY=2					\
+		DDR_TOPOLOGY=2					\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
 		WTP=${BUILD_DIR}/atf-tool			\
@@ -362,13 +358,10 @@ build_atf () {
 	### Build DDR3 2G 2CS
 	## Build DDR3 2G 2CS SPI
 	make distclean
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
-		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
-		${BUILD_DIR}/atf-tool/wtmi/*.d			\
-		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-2g-spi.bin
 	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
-		DDR_TOPLOGY=7					\
+		DDR_TOPOLOGY=7					\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
@@ -384,13 +377,10 @@ build_atf () {
 
 	## Build DDR3 2G 2CS MMC
 	make distclean
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
-		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
-		${BUILD_DIR}/atf-tool/wtmi/*.d			\
-		${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
+	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-2g-mmc.bin
 	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
-		DDR_TOPLOGY=7					\
+		DDR_TOPOLOGY=7					\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
 		WTP=${BUILD_DIR}/atf-tool			\

--- a/u-boot/u-boot.sh
+++ b/u-boot/u-boot.sh
@@ -220,7 +220,7 @@ build_atf () {
 	make distclean
 	make -j8 BL33=${BUILD_DIR}/u-boot-512m-spi.bin	\
 		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPOLOGY=0				\
+		DDR_TOPLOGY=0				\
 		BOOTDEV=SPINOR				\
 		WTP=${BUILD_DIR}/atf-tool		\
 		PLAT=a3700 all fip
@@ -238,7 +238,7 @@ build_atf () {
 	make distclean
 	make -j8 BL33=${BUILD_DIR}/u-boot-512m-mmc.bin	\
 		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPOLOGY=0				\
+		DDR_TOPLOGY=0				\
 		BOOTDEV=EMMCNORM			\
 		PARTNUM=1				\
 		WTP=${BUILD_DIR}/atf-tool		\
@@ -259,7 +259,7 @@ build_atf () {
 	make distclean
 	make -j8 BL33=${BUILD_DIR}/u-boot-1g-spi.bin	\
 		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPOLOGY=4				\
+		DDR_TOPLOGY=4				\
 		BOOTDEV=SPINOR				\
 		WTP=${BUILD_DIR}/atf-tool		\
 		PLAT=a3700 all fip
@@ -277,7 +277,7 @@ build_atf () {
 	make distclean
 	make -j8 BL33=${BUILD_DIR}/u-boot-1g-mmc.bin	\
 		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPOLOGY=4				\
+		DDR_TOPLOGY=4				\
 		BOOTDEV=EMMCNORM			\
 		PARTNUM=1				\
 		WTP=${BUILD_DIR}/atf-tool		\
@@ -297,7 +297,7 @@ build_atf () {
 	make distclean
 	make -j8 BL33=${BUILD_DIR}/u-boot-1g-spi.bin	\
 		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPOLOGY=2				\
+		DDR_TOPLOGY=2				\
 		BOOTDEV=SPINOR				\
 		WTP=${BUILD_DIR}/atf-tool		\
 		PLAT=a3700 all fip
@@ -315,7 +315,7 @@ build_atf () {
 	make distclean
 	make -j8 BL33=${BUILD_DIR}/u-boot-1g-mmc.bin	\
 		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPOLOGY=2				\
+		DDR_TOPLOGY=2				\
 		BOOTDEV=EMMCNORM			\
 		PARTNUM=1				\
 		WTP=${BUILD_DIR}/atf-tool		\
@@ -335,7 +335,7 @@ build_atf () {
 	make distclean
 	make -j8 BL33=${BUILD_DIR}/u-boot-2g-spi.bin	\
 		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPOLOGY=7				\
+		DDR_TOPLOGY=7				\
 		BOOTDEV=SPINOR				\
 		WTP=${BUILD_DIR}/atf-tool		\
 		PLAT=a3700 all fip
@@ -353,7 +353,7 @@ build_atf () {
 	make distclean
 	make -j8 BL33=${BUILD_DIR}/u-boot-2g-mmc.bin	\
 		CLOCKSPRESET=CPU_1200_DDR_750		\
-		DDR_TOPOLOGY=7				\
+		DDR_TOPLOGY=7				\
 		BOOTDEV=EMMCNORM			\
 		PARTNUM=1				\
 		WTP=${BUILD_DIR}/atf-tool		\

--- a/u-boot/u-boot.sh
+++ b/u-boot/u-boot.sh
@@ -116,6 +116,9 @@ build_clone_atf_tool() {
 	cat ${BUILD_DIR}/atf-tool/.git/refs/heads/${ATF_TOOL_BRANCH}	\
 		>> ${BUILD_LABEL_FILE}
 	echo "" >> ${BUILD_LABEL_FILE}
+
+	mkdir -p ${BUILD_DIR}/atf-tool-backup
+	cp -R ${BUILD_DIR}/atf-tool/* ${BUILD_DIR}/atf-tool-backup
 }
 
 build_export_toolchain() {
@@ -196,17 +199,8 @@ build_u_boot () {
 }
 
 build_atf_tool_clean () {
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.d		\
-		${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.d	\
-		${BUILD_DIR}/atf-tool/wtmi/*.d
-
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/wtmi_ddr/*.o		\
-		${BUILD_DDR}/atf-tool/ddr/wtmi_ddr/ddrcore/*.o
-
-	rm -rf ${BUILD_DIR}/atf-tool/wtmi/*.o
-
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/tim_ddr/clocks_ddr.txt
-	rm -rf ${BUILD_DIR}/atf-tool/ddr/tim_ddr/ddr_static.txt
+	rm -rf ${BUILD_DIR}/atf-tool/*
+	cp -R ${BUILD_DIR}/atf-tool-backup/* ${BUILD_DIR}/atf-tool/
 }
 
 build_atf () {
@@ -239,8 +233,9 @@ build_atf () {
 	make distclean
 	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-512m-spi.bin
-	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
+	make -j8 CLOCKSPRESET=CPU_1000_DDR_800			\
 		DDR_TOPOLOGY=0					\
+		USE_COHERENT_MEM=0				\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
@@ -258,8 +253,9 @@ build_atf () {
 	make distclean
 	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-512m-mmc.bin
-	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
+	make -j8 CLOCKSPRESET=CPU_1000_DDR_800			\
 		DDR_TOPOLOGY=0					\
+		USE_COHERENT_MEM=0				\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
 		WTP=${BUILD_DIR}/atf-tool			\
@@ -280,8 +276,9 @@ build_atf () {
 	make distclean
 	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-1g-spi.bin
-	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
+	make -j8 CLOCKSPRESET=CPU_1000_DDR_800			\
 		DDR_TOPOLOGY=4					\
+		USE_COHERENT_MEM=0				\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
@@ -299,8 +296,9 @@ build_atf () {
 	make distclean
 	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-1g-mmc.bin
-	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
+	make -j8 CLOCKSPRESET=CPU_1000_DDR_800			\
 		DDR_TOPOLOGY=4					\
+		USE_COHERENT_MEM=0				\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
 		WTP=${BUILD_DIR}/atf-tool			\
@@ -320,8 +318,9 @@ build_atf () {
 	make distclean
 	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-1g-spi.bin
-	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
+	make -j8 CLOCKSPRESET=CPU_1000_DDR_800			\
 		DDR_TOPOLOGY=2					\
+		USE_COHERENT_MEM=0				\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
@@ -339,8 +338,9 @@ build_atf () {
 	make distclean
 	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-1g-mmc.bin
-	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
+	make -j8 CLOCKSPRESET=CPU_1000_DDR_800			\
 		DDR_TOPOLOGY=2					\
+		USE_COHERENT_MEM=0				\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
 		WTP=${BUILD_DIR}/atf-tool			\
@@ -360,8 +360,9 @@ build_atf () {
 	make distclean
 	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-2g-spi.bin
-	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
+	make -j8 CLOCKSPRESET=CPU_1000_DDR_800			\
 		DDR_TOPOLOGY=7					\
+		USE_COHERENT_MEM=0				\
 		BOOTDEV=SPINOR					\
 		WTP=${BUILD_DIR}/atf-tool			\
 		PLAT=a3700 all fip
@@ -379,8 +380,9 @@ build_atf () {
 	make distclean
 	build_atf_tool_clean
 	export BL33=${BUILD_DIR}/u-boot-2g-mmc.bin
-	make -j8 CLOCKSPRESET=CPU_1200_DDR_750			\
+	make -j8 CLOCKSPRESET=CPU_1000_DDR_800			\
 		DDR_TOPOLOGY=7					\
+		USE_COHERENT_MEM=0				\
 		BOOTDEV=EMMCNORM				\
 		PARTNUM=1					\
 		WTP=${BUILD_DIR}/atf-tool			\

--- a/u-boot/u-boot.sh
+++ b/u-boot/u-boot.sh
@@ -135,6 +135,8 @@ build_u_boot () {
 	cd ${BUILD_DIR}/u-boot
 	make distclean
 
+	aarch64-linux-gnu-gcc --version
+
 	make espressobin_512m_spi_defconfig
 	make -j8 DEVICE_TREE=armada-3720-espressobin
 	if [ $? -ne 0 ]
@@ -202,6 +204,9 @@ build_atf () {
 		rm -rf ${IMAGE_DIR}/u-boot
 	fi
 	mkdir ${IMAGE_DIR}/u-boot
+
+	aarch64-linux-gnu-gcc --version
+	arm-linux-gnueabi-gcc --version
 
 	mkdir -p ${IMAGE_DIR}/u-boot/ddr3/512m/1cs/spi
 	mkdir -p ${IMAGE_DIR}/u-boot/ddr3/512m/1cs/mmc


### PR DESCRIPTION
Replace DDR_TOPOLOGY with DDR_TOPLOGY.

This commit will fix wrong DDR TOPLOGY images.