### PR TITLE
ch: u-boot: Save current commit information to build label as well

### DIFF
--- a/u-boot/u-boot.sh
+++ b/u-boot/u-boot.sh
@@ -121,7 +121,20 @@ build_clone_atf_tool() {
 	cp -R ${BUILD_DIR}/atf-tool/* ${BUILD_DIR}/atf-tool-backup
 }
 
+build_export_rootfs_commit () {
+	echo "Rootfs-extra Branch: \c" >> ${BUILD_LABEL_FILE}
+	git symbolic-ref --short -q HEAD >> ${BUILD_LABEL_FILE}
+
+	echo "Rootfs-extra commit: \c" >> ${BUILD_LABEL_FILE}
+	git rev-parse HEAD >> ${BUILD_LABEL_FILE}
+
+	echo "Locally modfied files:" >> ${BUILD_LABEL_FILE}
+	git status --porcelain >> ${BUILD_LABEL_FILE}
+}
+
 build_export_toolchain() {
+	build_export_rootfs_commit
+
 	export PATH=${TOOLCHAIN_DIR}/bin:${PATH}
 	export CROSS_COMPILE=aarch64-linux-gnu-
 


### PR DESCRIPTION
Different commit could build different u-boot image, but the build label
are the same, this commit will add rootfs-extra commit id to build label
file to make sure we are line up with every thing.

Signed-off-by: Ding Tao <i@dingtao.org>