### PR TITLE
ch: rootfs: tar: Use .tar rather than .tar.gz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,7 @@ all: rootfs u-boot
 # This target will pack all files in $(ROOTFS_DIR) to a single image file
 # to $(IMAGE_DIR)/image.tar.gz
 rootfs: overlay
-	tar -cjvf ${IMAGE_DIR}/rootfs.tar.bz2 -C ${ROOTFS_DIR} .	\
-		> /dev/null
+	tar -cvf ${IMAGE_DIR}/rootfs.tar -C ${ROOTFS_DIR} . > /dev/null
 
 # This target will add/deleate/alter file system's file after all files are
 # copied to $(ROOTFS_DIR)


### PR DESCRIPTION
Busybox default settings did not support unpack from a compressed tar
file, so let use the uncompressed tar file as rootfs.

Signed-off-by: Ding Tao <i@dingtao.org>