### PR TITLE
ch: rootfs: tar: Use .tar.xz rather than .tar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ all: rootfs u-boot
 # This target will pack all files in $(ROOTFS_DIR) to a single image file
 # to $(IMAGE_DIR)/image.tar.gz
 rootfs: overlay
-	tar -cvf ${IMAGE_DIR}/rootfs.tar -C ${ROOTFS_DIR} . > /dev/null
+	tar cvO -C ${ROOTFS_DIR}/ . | xz -z9eT0 > ${IMAGE_DIR}.tar.xz	\
+		> /dev/null
 
 # This target will add/deleate/alter file system's file after all files are
 # copied to $(ROOTFS_DIR)


### PR DESCRIPTION
Although busybox did not support unpack tarball from tar.xx, but we can
pipe the output to a compress program, so use .tar.xz instead of .tar.

Signed-off-by: Ding Tao <i@dingtao.org>